### PR TITLE
basic structure for index.cpp and move methods from readCollection.cpp

### DIFF
--- a/index.cpp
+++ b/index.cpp
@@ -1,0 +1,45 @@
+#include <iostream>
+#include <fstream>
+#include <cstdint>
+
+const int CHUNK_SIZE = 128;
+
+struct Chunk {
+    uint32_t docIds[CHUNK_SIZE];
+    int freq[CHUNK_SIZE];
+};
+
+uint32_t unpackTermID(uint64_t pack);
+uint32_t unpackDocID(uint64_t pack);
+
+int main() {
+    std::ifstream preIndex("mergedPreIndex");
+    if (!preIndex) { std::cerr << "Failed to open pre index file"; exit(1); }
+
+    uint64_t packedNum; int freq;
+    while (preIndex) {
+        Chunk currChunk;
+    
+        for (int i = 0; i < CHUNK_SIZE && preIndex >> packedNum >> freq; i++) {
+            uint32_t termID = unpackTermID(packedNum);
+            uint32_t docID = unpackDocID(packedNum);
+
+            currChunk.docIds[i] = docID;
+            currChunk.freq[i] = freq;
+        }
+    }
+}
+
+/*
+Returns the first 32 bits of the packed number, which is the termID
+*/
+uint32_t unpackTermID(uint64_t pack) {
+    return uint32_t(pack >> 32);
+}
+
+/*
+Returns the last 32 bits of the packed number, which is the docID
+*/
+uint32_t unpackDocID(uint64_t pack) {
+    return uint32_t(pack & 0xffffffffu);
+}

--- a/index.cpp
+++ b/index.cpp
@@ -18,15 +18,17 @@ int main() {
 
     uint64_t packedNum; int freq;
     while (preIndex) {
-        Chunk currChunk;
-    
-        for (int i = 0; i < CHUNK_SIZE && preIndex >> packedNum >> freq; i++) {
+        Chunk currChunk{};
+        int i = 0;
+        for (; i < CHUNK_SIZE && preIndex >> packedNum >> freq; i++) {
             uint32_t termID = unpackTermID(packedNum);
             uint32_t docID = unpackDocID(packedNum);
 
             currChunk.docIds[i] = docID;
             currChunk.freq[i] = freq;
         }
+
+        if (i == 0) { break; }
     }
 }
 

--- a/readCollection.cpp
+++ b/readCollection.cpp
@@ -14,8 +14,6 @@ const int FILE_PER_DOC = 34539;
 const int NUM_FILES = 256;
 
 uint64_t pack(uint32_t termID, uint32_t docID);
-uint32_t unpackTermID(uint64_t pack);
-uint32_t unpackDocID(uint64_t pack);
 void tokenizeString(const std::string& line, std::vector<std::string>& tokens);
 void writeTempFile(const std::vector<uint64_t>& buffer, int iter);
 void writeOtherFiles(const std::vector<std::string>& termToWord,
@@ -76,20 +74,6 @@ Returns a 64 bit unsigned integer in the following representation:
 */
 uint64_t pack(uint32_t termID, uint32_t docID) {
     return (uint64_t(termID) << 32) | docID;
-}
-
-/*
-Returns the first 32 bits of the packed number, which is the termID
-*/
-uint32_t unpackTermID(uint64_t pack) {
-    return uint32_t(pack >> 32);
-}
-
-/*
-Returns the last 32 bits of the packed number, which is the docID
-*/
-uint32_t unpackDocID(uint64_t pack) {
-    return uint32_t(pack & 0xffffffffu);
 }
 
 /*


### PR DESCRIPTION
Moves unpacking methods from readCollection.cpp to index.cpp.

Sets up basic structure for reading in chunks.